### PR TITLE
Fix NoMethodError

### DIFF
--- a/wazuh/attributes/default.rb
+++ b/wazuh/attributes/default.rb
@@ -332,3 +332,5 @@ default['ossec']['conf']['all']['localfile'] = [
 #         }
 #       }
 #]
+
+default['wazuh-agent']['version'] = nil


### PR DESCRIPTION
https://github.com/pyama86/wazuh-chef/pull/1
これで `node['wazuh-agent']['version']` の要求が入ったが `node['wazuh-agent']` がデフォルトで存在しないので以下のエラーになっている。

本PRではデフォルト値を定義してエラーが発生しないようにした。

```
NoMethodError
-------------
undefined method `[]' for nil:NilClass

Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/wazuh/recipes/agent.rb:23:in `block in from_file'
  /var/chef/cache/cookbooks/wazuh/recipes/agent.rb:22:in `from_file'
  /var/chef/cache/cookbooks/lolipop-base/recipes/wazuh.rb:8:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/wazuh/recipes/agent.rb:

 16:  # See the License for the specific language governing permissions and
 17:  # limitations under the License.
 18:  #
 19:  include_recipe 'apt::default'
 20:  include_recipe 'wazuh::repository'
 21:
 22:  package 'wazuh-agent' do
 23>>   version node['wazuh-agent']['version'] if node['wazuh-agent']['version']
 24:  end
 25:
 26:  dir = node['ossec']['dir']
 27:  agent_auth = node['ossec']['agent_auth']
 28:
 29:  args = "-m #{agent_auth['host']} -p #{agent_auth['port']} -A #{agent_auth['name']}"
 30:
 31:  if agent_auth['ca'] && File.exist?(agent_auth['ca'])
 32:    args << ' -v ' + agent_auth['ca']
```